### PR TITLE
Add delay to fix cold boot issue on SGB core for Analogue Pocket

### DIFF
--- a/src/code/super-game-boy-border-injector.asm
+++ b/src/code/super-game-boy-border-injector.asm
@@ -58,7 +58,7 @@ ENDM
 SuperGameBoyBorderInjector:
     ld        a, c
     cp        $14
-    jr        nz, .end ;not in SGB mode, return
+    jp        nz, .end ;not in SGB mode, return
 
     push    bc
     push    de
@@ -66,22 +66,24 @@ SuperGameBoyBorderInjector:
 
     ; Delay 0.6875s for SGB boot up (needed for Analogue Pocket SGB core at least)
     ld a, $04
-    ld [rIE], a
+    ld [rIE], a ; enable timer interrupt, but rIME is still not enabled
+    xor a, a
+    ld [rTMA], a ; set timer modulo for 256 clicks per interrupt (usually the default)
     ld a, $fc
-    ld [rTAC], a
-    ld a, $f5 ; Waits for 0.6875s
+    ld [rTAC], a ; enable timer with 1/4096 click speed
+    ld a, $0b ; Will wait 11 interrupts, or 0.6875s
     ei
     nop
 .halt_loop:
     halt
     nop
-    inc a
+    dec a
     jr nz, .halt_loop
     di
     xor a, a
-    ld [rIE], a
+    ld [rIE], a ; turn off timer interrupt
     ld a, $f8
-    ld [rTAC], a
+    ld [rTAC], a ; turn off timer
 
     ; freeze GB screen to avoid garbled graphics being shown when transfering later to VRAM
     ld        hl, SGB_COMMAND_FREEZE_SCREEN

--- a/src/code/super-game-boy-border-injector.asm
+++ b/src/code/super-game-boy-border-injector.asm
@@ -58,32 +58,13 @@ ENDM
 SuperGameBoyBorderInjector:
     ld        a, c
     cp        $14
-    jp        nz, .end ;not in SGB mode, return
+    jr        nz, .end ;not in SGB mode, return
 
     push    bc
     push    de
     push    hl
 
-    ; Delay 0.6875s for SGB boot up (needed for Analogue Pocket SGB core at least)
-    ld a, $04
-    ld [rIE], a ; enable timer interrupt, but rIME is still not enabled
-    xor a, a
-    ld [rTMA], a ; set timer modulo for 256 clicks per interrupt (usually the default)
-    ld a, $fc
-    ld [rTAC], a ; enable timer with 1/4096 click speed
-    ld a, $0b ; Will wait 11 interrupts, or 0.6875s
-    ei
-    nop
-.halt_loop:
-    halt
-    nop
-    dec a
-    jr nz, .halt_loop
     di
-    xor a, a
-    ld [rIE], a ; turn off timer interrupt
-    ld a, $f8
-    ld [rTAC], a ; turn off timer
 
     ; freeze GB screen to avoid garbled graphics being shown when transfering later to VRAM
     ld        hl, SGB_COMMAND_FREEZE_SCREEN

--- a/src/code/super-game-boy-border-injector.asm
+++ b/src/code/super-game-boy-border-injector.asm
@@ -64,7 +64,24 @@ SuperGameBoyBorderInjector:
     push    de
     push    hl
 
+    ; Delay 0.6875s for SGB boot up (needed for Analogue Pocket SGB core at least)
+    ld a, $04
+    ld [rIE], a
+    ld a, $fc
+    ld [rTAC], a
+    ld a, $f5 ; Waits for 0.6875s
+    ei
+    nop
+.halt_loop:
+    halt
+    nop
+    inc a
+    jr nz, .halt_loop
     di
+    xor a, a
+    ld [rIE], a
+    ld a, $f8
+    ld [rTAC], a
 
     ; freeze GB screen to avoid garbled graphics being shown when transfering later to VRAM
     ld        hl, SGB_COMMAND_FREEZE_SCREEN

--- a/src/expansion_sgb.asm
+++ b/src/expansion_sgb.asm
@@ -9,6 +9,34 @@ SECTION "SGB Bank - Code", ROMX[$4000], BANK[SGB_CODE_BANK]
 INCLUDE "code/super-game-boy-border-injector.asm"
 
 sgb_init:
+    ; Exit early if not SGB
+    ld a, c
+    cp a, $14
+    ret nz
+
+    ; Disable LCD
+    ld hl, rLY
+    ld a, $92
+.wait_for_vblank:
+    cp a, [HL]
+    jr nz, .wait_for_vblank
+    xor a, a
+    ldh [rLCDC], a
+
+    ; Delay for SGB warm up
+    ld hl, rDIV ; Operates at 16384 Hz on SGB2, 16779 on SGB1
+    ld b, $2d ; 45*256/16779 = 0.69 seconds
+    xor a, a
+.inner_delay_loop:
+    cp a, [hl]
+    jr nz, .inner_delay_loop
+.reset_inner_loop:
+    cp a, [hl]
+    jr z, .reset_inner_loop
+    dec b
+    jr nz, .inner_delay_loop
+
+    ; Call border injector
     call SuperGameBoyBorderInjector
     ret
 


### PR DESCRIPTION
Needed 0.6875s of delay (0.625s wasn't enough)